### PR TITLE
switch between graph and gantt page without losing selected dag run.

### DIFF
--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -62,6 +62,15 @@
       .tickFormat("%H:%M:%S");
     gantt(data.tasks);
   });
+  $('a').on('click', function(event) {
+        if ($(this).attr('href').match('/admin/airflow/graph')) {
+            query = window.location.search
+            if (query.match("execution_date=")) {
+              event.preventDefault()
+              window.location.href = '/admin/airflow/graph' + query
+            }
+        }
+  });
 </script>
 
 {% endblock %}

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -365,6 +365,14 @@
         }
     );
 
+    $('a').on('click', function(event) {
+        if ($(this).attr('href').match('/admin/airflow/gantt')) {
+            console.log('Go to Gantt with current dag run.')
+            event.preventDefault()
+            query = window.location.search
+            window.location.href = '/admin/airflow/gantt' + query
+        }
+    });
     </script>
 
 


### PR DESCRIPTION
in airflow graph view, Run dropdown list, select a previous job run and click Go. It will display graph view of your selected run. However, if I click "Gantt" tab, it will always display the gantt chart of latest run. The run I selected is lost in context.
