### PR TITLE
fix tree view, display end time for dag run

### DIFF
--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -380,5 +380,34 @@ function click(d) {
   }
 }
 set_tooltip();
+
+(function calc_end_time_for_dag_run() {
+  var state_boxes = $('.stateboxes')
+  if (state_boxes.length == 0 || $(state_boxes[0]).children().length == 0) {
+    return
+  }
+  var dag_run_count = $(state_boxes[0]).children().length
+  var end_times = []
+  var regex = /<br>Ended: ([^<]+)<br>/
+  for(var i = 1; i < state_boxes.length; ++i) {
+    for(j = 0; j < dag_run_count; ++j) {
+      var tooltip_content = $($(state_boxes[i]).children()[j]).attr('data-original-title')
+      var matches = regex.exec(tooltip_content)
+      if(matches != null) {
+        var end_time = matches[1]
+        if (typeof(end_times[j]) === "undefined" || end_time > end_times[j]) {
+          end_times[j] = end_time
+        }
+      }
+    }
+  }
+  console.log(end_times)
+  for(var i = 0; i < dag_run_count; ++i) {
+    var $dag_run_circle = $($(state_boxes[0]).children()[i])
+    var old_tips = $dag_run_circle.attr('data-original-title')
+    var new_tips = old_tips.replace(regex, '<br>Ended: ' + end_times[i] + '<br>')
+    $dag_run_circle.attr('data-original-title', new_tips)
+  }
+})()
   </script>
 {% endblock %}


### PR DESCRIPTION
go to airflow tree view, all cells in the top row (DAG) have "Ended" time as null. But cells in following rows (tasks) have valid end time.

Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
